### PR TITLE
fix: bring block cache back

### DIFF
--- a/nodes/models/flux.py
+++ b/nodes/models/flux.py
@@ -290,6 +290,7 @@ class NunchakuFluxDiTLoader:
             self.model_path = model_path
             self.device = device
             self.cpu_offload = cpu_offload_enabled
+            self.data_type = data_type
         self.transformer = apply_cache_on_transformer(
             transformer=self.transformer, residual_diff_threshold=cache_threshold
         )

--- a/wrappers/flux.py
+++ b/wrappers/flux.py
@@ -236,7 +236,7 @@ class ComfyFluxWrapper(nn.Module):
         if self.pulid_pipeline is not None:
             self.model.transformer_blocks[0].pulid_ca = self.pulid_pipeline.pulid_ca
 
-        if getattr(model, "_is_cached", False):
+        if model.residual_diff_threshold_multi != 0 or getattr(model, "_is_cached", False):
             # A more robust caching strategy
             cache_invalid = False
 


### PR DESCRIPTION
1. checking residual_diff_threshold for caching strategy.
2. set the data_type during the initial model loading to avoid repeated model loading.