### PR TITLE
feat: update doc for latest huggingface cli usage

### DIFF
--- a/docs/source/developer/contribution_guide.rst
+++ b/docs/source/developer/contribution_guide.rst
@@ -73,7 +73,7 @@ Running Tests
 
 .. note::
 
-   ``$YOUR_HF_TOKEN`` is your Hugging Face access token, required for downloading models and datasets. Create one at https://huggingface.co/settings/tokens. If you have already logged in with ``huggingface-cli login``, you may omit this variable.
+   ``$YOUR_HF_TOKEN`` is your Hugging Face access token, required for downloading models and datasets. Create one at https://huggingface.co/settings/tokens. If you have already logged in with ``hf auth login``, you may omit this variable.
 
 Writing Tests
 ~~~~~~~~~~~~~

--- a/docs/source/get_started/usage.rst
+++ b/docs/source/get_started/usage.rst
@@ -27,11 +27,16 @@ Alternatively, use the following commands:
 
 .. code-block:: shell
 
-   huggingface-cli download comfyanonymous/flux_text_encoders clip_l.safetensors --local-dir models/text_encoders
-   huggingface-cli download comfyanonymous/flux_text_encoders t5xxl_fp16.safetensors --local-dir models/text_encoders
-   huggingface-cli download black-forest-labs/FLUX.1-schnell ae.safetensors --local-dir models/vae
+   hf download comfyanonymous/flux_text_encoders clip_l.safetensors --local-dir models/text_encoders
+   hf download comfyanonymous/flux_text_encoders t5xxl_fp16.safetensors --local-dir models/text_encoders
+   hf download black-forest-labs/FLUX.1-schnell ae.safetensors --local-dir models/vae
 
 Then, download the nunchaku models from `Hugging Face <hf_nunchaku_>`_ or `ModelScope <ms_nunchaku_>`_.
+For example, to download the Nunchaku Flux.1 dev models from Hugging Face, run:
+
+.. code-block:: shell
+
+   hf download nunchaku-tech/nunchaku-flux.1-dev svdq-int4_r32-flux.1-dev.safetensors --local-dir models/unet/
 
 .. note::
 

--- a/docs/source/nodes/preprocessors.rst
+++ b/docs/source/nodes/preprocessors.rst
@@ -29,7 +29,7 @@ This node applies a depth estimation model to an input image to produce a corres
 
     .. code-block:: bash
 
-        huggingface-cli download LiheYoung/depth-anything-large-hf --local-dir models/checkpoints/depth-anything-large-hf
+        hf download LiheYoung/depth-anything-large-hf --local-dir models/checkpoints/depth-anything-large-hf
 
 .. seealso::
 


### PR DESCRIPTION
I received the following prompt when installing the model
```
⚠️  Warning: 'huggingface-cli download' is deprecated. Use 'hf download' instead.
```
So this Pull Request is used to update the parts in the document that involve downloading using the huggingface cli