### PR TITLE
fix: changed device arg to meta for T5XXLModel ctor

### DIFF
--- a/nodes/models/text_encoder.py
+++ b/nodes/models/text_encoder.py
@@ -296,10 +296,9 @@ def nunchaku_flux_clip(nunchaku_t5_path: str | os.PathLike[str], dtype_t5=None) 
             )
 
             # Use meta device for T5XXL to avoid loading into memory before replacement
-            with torch.device("meta"):
-                self.t5xxl = comfy.text_encoders.sd3_clip.T5XXLModel(
-                    device=device, dtype=dtype_t5, model_options=model_options
-                )
+            self.t5xxl = comfy.text_encoders.sd3_clip.T5XXLModel(
+                device="meta", dtype=dtype_t5, model_options=model_options
+            )
 
             transformer = NunchakuT5EncoderModel.from_pretrained(nunchaku_t5_path, device=device, torch_dtype=dtype_t5)
             transformer.forward = types.MethodType(nunchaku_t5_forward, transformer)


### PR DESCRIPTION
Removed the with torch.device("meta") line since the device is now explicitly set to meta.
This resolves an OOM error when running with lower vram graphics cards. When the device is not set to meta explicitly, memory allocation will occur on the cpu or whatever is passed in to the constructor. This causes a full float16 allocation on device ram. Hard coding the device to meta has resolved this issue for my machine. In my case the process would halt with the following error when trying to initialize a linear operation in T5Attention.

```
got prompt
[MultiGPU Initialization] current_device set to: cuda:0
Using xformers attention in VAE
Using xformers attention in VAE
VAE load device: cuda:0, offload device: cpu, dtype: torch.bfloat16
GPU 0 (NVIDIA GeForce RTX 3060) Memory: 11906.8125 MiB
VRAM < 14GiB, enabling CPU offload
Injecting quantized module
model_type FLUX
!!! Exception during processing !!! Allocation on device 
Traceback (most recent call last):
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/execution.py", line 496, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, hidden_inputs=hidden_inputs)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/execution.py", line 315, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, hidden_inputs=hidden_inputs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/custom_nodes/comfyui-lora-manager/py/metadata_collector/metadata_hook.py", line 165, in async_map_node_over_list_with_metadata
    results = await original_map_node_over_list(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/execution.py", line 289, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/execution.py", line 277, in process_inputs
    result = f(**inputs)
             ^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/custom_nodes/ComfyUI-nunchaku/nodes/models/text_encoder.py", line 103, in load_text_encoder
    clip = load_text_encoder_state_dicts(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/custom_nodes/ComfyUI-nunchaku/nodes/models/text_encoder.py", line 396, in load_text_encoder_state_dicts
    clip = comfy.sd.CLIP(
           ^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/comfy/sd.py", line 110, in __init__
    self.cond_stage_model = clip(**(params))
                            ^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/custom_nodes/ComfyUI-nunchaku/nodes/models/text_encoder.py", line 300, in __init__
    self.t5xxl = comfy.text_encoders.sd3_clip.T5XXLModel(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/comfy/text_encoders/sd3_clip.py", line 19, in __init__
    super().__init__(device=device, layer=layer, layer_idx=layer_idx, textmodel_json_config=textmodel_json_config, dtype=dtype, special_tokens={"end": 1, "pad": 0}, model_class=comfy.text_encoders.t5.T5, enable_attention_masks=attention_mask, return_attention_masks=attention_mask, model_options=model_options)
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/comfy/sd1_clip.py", line 121, in __init__
    self.transformer = model_class(config, dtype, device, self.operations)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/comfy/text_encoders/t5.py", line 232, in __init__
    self.encoder = T5Stack(self.num_layers, model_dim, inner_dim, config_dict["d_ff"], config_dict["dense_act_fn"], config_dict["is_gated_act"], config_dict["num_heads"], config_dict["model_type"] != "umt5", dtype, device, operations)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/comfy/text_encoders/t5.py", line 197, in __init__
    [T5Block(model_dim, inner_dim, ff_dim, ff_activation, gated_act, num_heads, relative_attention_bias=((not relative_attention) or (i == 0)), dtype=dtype, device=device, operations=operations) for i in range(num_layers)]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/comfy/text_encoders/t5.py", line 185, in __init__
    self.layer.append(T5LayerFF(model_dim, ff_dim, ff_activation, gated_act, dtype, device, operations))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/comfy/text_encoders/t5.py", line 57, in __init__
    self.DenseReluDense = T5DenseGatedActDense(model_dim, ff_dim, ff_activation, dtype, device, operations)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/ComfyUI/comfy/text_encoders/t5.py", line 41, in __init__
    self.wo = operations.Linear(ff_dim, model_dim, bias=False, dtype=dtype, device=device)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ai/stableDiffusion/comfyui/.venv/lib64/python3.12/site-packages/torch/nn/modules/linear.py", line 106, in __init__
    torch.empty((out_features, in_features), **factory_kwargs)
  File "/mnt/ai/stableDiffusion/comfyui/.venv/lib64/python3.12/site-packages/torch/utils/_device.py", line 104, in __torch_function__
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
torch.OutOfMemoryError: Allocation on device 

Got an OOM, unloading all loaded models.
```