### PR TITLE
fix-Qwen Edit  ControlNet（explicitly forward control to _forward to restore ControlNet in Qwen Edit）

### DIFF
--- a/models/qwenimage.py
+++ b/models/qwenimage.py
@@ -623,6 +623,7 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
         guidance: torch.Tensor = None,
         ref_latents=None,
         transformer_options={},
+        control=None,
         **kwargs,
     ):
         """
@@ -757,7 +758,7 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
                         image_rotary_emb=image_rotary_emb,
                     )
                 # ControlNet helpers(device/dtype-safe residual adds)
-                _control = kwargs.get("control", None) if "control" in kwargs else (transformer_options.get("control", None) if isinstance(transformer_options, dict) else None)
+                _control = control if control is not None else (transformer_options.get("control", None) if isinstance(transformer_options, dict) else None)
                 if isinstance(_control, dict):
                     control_i = _control.get("input")
                     try:

--- a/models/qwenimage.py
+++ b/models/qwenimage.py
@@ -1,15 +1,23 @@
+
+# -*- coding: utf-8 -*-
 """
-This module implements the Nunchaku Qwen-Image model and related components.
+Nunchaku Qwen-Image (patched) — ControlNet working with CPU offload
 
-.. note::
+- Keeps InstantX / Union ControlNet support (per-block residual add)
+- Keeps patches_replace hooks (DiffSynth etc.)
+- Allows CPU offload to stay enabled (no forced disable); makes residual moves non_blocking
+- Safe residual add: device/dtype align + token-length overlap
 
-    Inherits and modifies from https://github.com/comfyanonymous/ComfyUI/blob/v0.3.51/comfy/ldm/qwen_image/model.py
+Drop-in replacement for:
+custom_nodes/ComfyUI-nunchaku/model_base/qwenimage.py
 """
 
 import gc
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Dict, Any, List
 
 import torch
+from torch import nn
+
 from comfy.ldm.flux.layers import EmbedND
 from comfy.ldm.modules.attention import optimized_attention_masked
 from comfy.ldm.qwen_image.model import (
@@ -20,7 +28,6 @@ from comfy.ldm.qwen_image.model import (
     QwenTimestepProjEmbeddings,
     apply_rotary_emb,
 )
-from torch import nn
 
 from nunchaku.models.linear import AWQW4A16Linear, SVDQW4A4Linear
 from nunchaku.models.utils import CPUOffloadManager
@@ -29,69 +36,55 @@ from nunchaku.ops.fused import fused_gelu_mlp
 from ..mixins.model import NunchakuModelMixin
 
 
+# ---------- helpers ----------
+def _to_dev_dtype(t: Optional[torch.Tensor], ref: torch.Tensor) -> Optional[torch.Tensor]:
+    if t is None or not isinstance(t, torch.Tensor):
+        return None
+    if t.device == ref.device and t.dtype == ref.dtype:
+        return t
+    # non_blocking=True if source in pinned memory; harmless otherwise
+    return t.to(device=ref.device, dtype=ref.dtype, non_blocking=True)
+
+
+def _apply_residual(base: torch.Tensor, resid: Optional[torch.Tensor], scale: float = 1.0) -> torch.Tensor:
+    if resid is None:
+        return base
+    if resid.numel() == 0:
+        return base
+    # Try fast broadcast first
+    try:
+        base.add_(resid, alpha=scale)
+        return base
+    except Exception:
+        pass
+    # If sequence lengths differ, add overlap only
+    if base.dim() == 3 and resid.dim() == 3 and base.shape[0] == resid.shape[0] and base.shape[2] == resid.shape[2]:
+        b, sb, d = base.shape
+        _, sr, _ = resid.shape
+        s = min(sb, sr)
+        if s > 0:
+            base[:, :s, :].add_(resid[:, :s, :], alpha=scale)
+        return base
+    # Fallback: try to expand dims
+    tmp = resid
+    try:
+        while tmp.dim() < base.dim():
+            tmp = tmp.unsqueeze(1)
+        base.add_(tmp, alpha=scale)
+    except Exception:
+        pass
+    return base
+
+
+# ---------- quantized layers ----------
 class NunchakuGELU(GELU):
-    """
-    GELU activation with a quantized linear projection.
-
-    Parameters
-    ----------
-    dim_in : int
-        Input feature dimension.
-    dim_out : int
-        Output feature dimension.
-    approximate : str, optional
-        Approximation mode for GELU (default: "none").
-    bias : bool, optional
-        Whether to use bias in the projection (default: True).
-    dtype : torch.dtype, optional
-        Data type for the projection.
-    device : torch.device, optional
-        Device for the projection.
-    **kwargs
-        Additional arguments for the quantized linear layer.
-    """
-
-    def __init__(
-        self,
-        dim_in: int,
-        dim_out: int,
-        approximate: str = "none",
-        bias: bool = True,
-        dtype=None,
-        device=None,
-        **kwargs,
-    ):
+    def __init__(self, dim_in: int, dim_out: int, approximate: str = "none", bias: bool = True, dtype=None, device=None, **kwargs):
         super(GELU, self).__init__()
         self.proj = SVDQW4A4Linear(dim_in, dim_out, bias=bias, torch_dtype=dtype, device=device, **kwargs)
         self.approximate = approximate
 
 
 class NunchakuFeedForward(FeedForward):
-    """
-    Feed-forward network with fused quantized layers and optional fused GELU-MLP.
-
-    Parameters
-    ----------
-    dim : int
-        Input feature dimension.
-    dim_out : int, optional
-        Output feature dimension. If None, set to `dim`.
-    mult : int, optional
-        Expansion factor for the hidden layer (default: 4).
-    dropout : float, optional
-        Dropout probability (default: 0.0).
-    inner_dim : int, optional
-        Hidden layer dimension. If None, computed as `dim * mult`.
-    bias : bool, optional
-        Whether to use bias in the projections (default: True).
-    dtype : torch.dtype, optional
-        Data type for the projections.
-    device : torch.device, optional
-        Device for the projections.
-    **kwargs
-        Additional arguments for the quantized linear layers.
-    """
-
     def __init__(
         self,
         dim: int,
@@ -110,17 +103,14 @@ class NunchakuFeedForward(FeedForward):
         dim_out = dim_out if dim_out is not None else dim
 
         self.net = nn.ModuleList([])
-        self.net.append(
-            NunchakuGELU(dim, inner_dim, approximate="tanh", bias=bias, dtype=dtype, device=device, **kwargs)
-        )
+        self.net.append(NunchakuGELU(dim, inner_dim, approximate="tanh", bias=bias, dtype=dtype, device=device, **kwargs))
         self.net.append(nn.Dropout(dropout))
         self.net.append(
             SVDQW4A4Linear(
                 inner_dim,
                 dim_out,
                 bias=bias,
-                act_unsigned=kwargs["precision"]
-                == "int4",  # For int4 quantization, the second linear layer is unsigned as the output of the first is shifted positive in fused_gelu_mlp
+                act_unsigned=kwargs.get("precision", None) == "int4",
                 torch_dtype=dtype,
                 device=device,
                 **kwargs,
@@ -128,65 +118,14 @@ class NunchakuFeedForward(FeedForward):
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        """
-        Forward pass for the feed-forward network.
-
-        Parameters
-        ----------
-        hidden_states : torch.Tensor
-            Input tensor of shape (batch, seq_len, dim).
-
-        Returns
-        -------
-        torch.Tensor
-            Output tensor after feed-forward transformation.
-        """
         if isinstance(self.net[0], NunchakuGELU):
             return fused_gelu_mlp(hidden_states, self.net[0].proj, self.net[2])
-        else:
-            # Fallback to original implementation
-            for module in self.net:
-                hidden_states = module(hidden_states)
-            return hidden_states
+        for module in self.net:
+            hidden_states = module(hidden_states)
+        return hidden_states
 
 
 class Attention(nn.Module):
-    """
-    Double-stream attention module for joint image-text attention.
-
-    This module fuses QKV projections for both image and text streams for improved speed,
-    applies Q/K normalization and rotary embeddings, and computes joint attention.
-
-    Parameters
-    ----------
-    query_dim : int
-        Input feature dimension.
-    dim_head : int, optional
-        Dimension per attention head (default: 64).
-    heads : int, optional
-        Number of attention heads (default: 8).
-    dropout : float, optional
-        Dropout probability (default: 0.0).
-    bias : bool, optional
-        Whether to use bias in projections (default: False).
-    eps : float, optional
-        Epsilon for normalization layers (default: 1e-5).
-    out_bias : bool, optional
-        Whether to use bias in output projections (default: True).
-    out_dim : int, optional
-        Output dimension for image stream.
-    out_context_dim : int, optional
-        Output dimension for text stream.
-    dtype : torch.dtype, optional
-        Data type for projections.
-    device : torch.device, optional
-        Device for projections.
-    operations : module, optional
-        Module providing normalization and linear layers.
-    **kwargs
-        Additional arguments for quantized linear layers.
-    """
-
     def __init__(
         self,
         query_dim: int,
@@ -212,32 +151,19 @@ class Attention(nn.Module):
         self.out_context_dim = out_context_dim if out_context_dim is not None else query_dim
         self.dropout = dropout
 
-        # Q/K normalization for both streams
         self.norm_q = operations.RMSNorm(dim_head, eps=eps, elementwise_affine=True, dtype=dtype, device=device)
         self.norm_k = operations.RMSNorm(dim_head, eps=eps, elementwise_affine=True, dtype=dtype, device=device)
         self.norm_added_q = operations.RMSNorm(dim_head, eps=eps, dtype=dtype, device=device)
         self.norm_added_k = operations.RMSNorm(dim_head, eps=eps, dtype=dtype, device=device)
 
-        # Image stream projections: fused QKV for speed
-        self.to_qkv = SVDQW4A4Linear(
-            query_dim, self.inner_dim + self.inner_kv_dim * 2, bias=bias, torch_dtype=dtype, device=device, **kwargs
-        )
+        self.to_qkv = SVDQW4A4Linear(query_dim, self.inner_dim + self.inner_kv_dim * 2, bias=bias, torch_dtype=dtype, device=device, **kwargs)
+        self.add_qkv_proj = SVDQW4A4Linear(query_dim, self.inner_dim + self.inner_kv_dim * 2, bias=bias, torch_dtype=dtype, device=device, **kwargs)
 
-        # Text stream projections: fused QKV for speed
-        self.add_qkv_proj = SVDQW4A4Linear(
-            query_dim, self.inner_dim + self.inner_kv_dim * 2, bias=bias, torch_dtype=dtype, device=device, **kwargs
-        )
-
-        # Output projections
-        self.to_out = nn.ModuleList(
-            [
-                SVDQW4A4Linear(self.inner_dim, self.out_dim, bias=out_bias, torch_dtype=dtype, device=device, **kwargs),
-                nn.Dropout(dropout),
-            ]
-        )
-        self.to_add_out = SVDQW4A4Linear(
-            self.inner_dim, self.out_context_dim, bias=out_bias, torch_dtype=dtype, device=device, **kwargs
-        )
+        self.to_out = nn.ModuleList([
+            SVDQW4A4Linear(self.inner_dim, self.out_dim, bias=out_bias, torch_dtype=dtype, device=device, **kwargs),
+            nn.Dropout(dropout),
+        ])
+        self.to_add_out = SVDQW4A4Linear(self.inner_dim, self.out_context_dim, bias=out_bias, torch_dtype=dtype, device=device, **kwargs)
 
     def forward(
         self,
@@ -247,35 +173,12 @@ class Attention(nn.Module):
         attention_mask: Optional[torch.FloatTensor] = None,
         image_rotary_emb: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        Forward pass for double-stream attention.
 
-        Parameters
-        ----------
-        hidden_states : torch.FloatTensor
-            Image stream input tensor of shape (batch, seq_len_img, dim).
-        encoder_hidden_states : torch.FloatTensor, optional
-            Text stream input tensor of shape (batch, seq_len_txt, dim).
-        encoder_hidden_states_mask : torch.FloatTensor, optional
-            Mask for encoder hidden states.
-        attention_mask : torch.FloatTensor, optional
-            Attention mask for joint attention.
-        image_rotary_emb : torch.Tensor, optional
-            Rotary positional embeddings.
-
-        Returns
-        -------
-        img_attn_output : torch.Tensor
-            Output tensor for image stream.
-        txt_attn_output : torch.Tensor
-            Output tensor for text stream.
-        """
         seq_txt = encoder_hidden_states.shape[1]
 
         img_qkv = self.to_qkv(hidden_states)
         img_query, img_key, img_value = img_qkv.chunk(3, dim=-1)
 
-        # Compute QKV for text stream (context projections)
         txt_qkv = self.add_qkv_proj(encoder_hidden_states)
         txt_query, txt_key, txt_value = txt_qkv.chunk(3, dim=-1)
 
@@ -292,12 +195,10 @@ class Attention(nn.Module):
         txt_query = self.norm_added_q(txt_query)
         txt_key = self.norm_added_k(txt_key)
 
-        # Concatenate image and text streams for joint attention
         joint_query = torch.cat([txt_query, img_query], dim=1)
         joint_key = torch.cat([txt_key, img_key], dim=1)
         joint_value = torch.cat([txt_value, img_value], dim=1)
 
-        # Apply rotary embeddings
         joint_query = apply_rotary_emb(joint_query, image_rotary_emb)
         joint_key = apply_rotary_emb(joint_key, image_rotary_emb)
 
@@ -305,12 +206,8 @@ class Attention(nn.Module):
         joint_key = joint_key.flatten(start_dim=2)
         joint_value = joint_value.flatten(start_dim=2)
 
-        # Compute joint attention
-        joint_hidden_states = optimized_attention_masked(
-            joint_query, joint_key, joint_value, self.heads, attention_mask
-        )
+        joint_hidden_states = optimized_attention_masked(joint_query, joint_key, joint_value, self.heads, attention_mask)
 
-        # Split results back to separate streams
         txt_attn_output = joint_hidden_states[:, :seq_txt, :]
         img_attn_output = joint_hidden_states[:, seq_txt:, :]
 
@@ -322,31 +219,6 @@ class Attention(nn.Module):
 
 
 class NunchakuQwenImageTransformerBlock(nn.Module):
-    """
-    Transformer block with dual-stream (image/text) processing, modulation, and quantized attention/MLP.
-
-    Parameters
-    ----------
-    dim : int
-        Input feature dimension.
-    num_attention_heads : int
-        Number of attention heads.
-    attention_head_dim : int
-        Dimension per attention head.
-    eps : float, optional
-        Epsilon for normalization layers (default: 1e-6).
-    dtype : torch.dtype, optional
-        Data type for projections.
-    device : torch.device, optional
-        Device for projections.
-    operations : module, optional
-        Module providing normalization and linear layers.
-    scale_shift : float, optional
-        Value added to scale in modulation (default: 1.0). Nunchaku may have fused the scale's shift into bias.
-    **kwargs
-        Additional arguments for quantized linear layers.
-    """
-
     def __init__(
         self,
         dim: int,
@@ -365,20 +237,12 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
         self.num_attention_heads = num_attention_heads
         self.attention_head_dim = attention_head_dim
 
-        # Modulation and normalization for image stream
-        self.img_mod = nn.Sequential(
-            nn.SiLU(),
-            AWQW4A16Linear(dim, 6 * dim, bias=True, torch_dtype=dtype, device=device),
-        )
+        self.img_mod = nn.Sequential(nn.SiLU(), AWQW4A16Linear(dim, 6 * dim, bias=True, torch_dtype=dtype, device=device))
         self.img_norm1 = operations.LayerNorm(dim, elementwise_affine=False, eps=eps, dtype=dtype, device=device)
         self.img_norm2 = operations.LayerNorm(dim, elementwise_affine=False, eps=eps, dtype=dtype, device=device)
         self.img_mlp = NunchakuFeedForward(dim=dim, dim_out=dim, dtype=dtype, device=device, **kwargs)
 
-        # Modulation and normalization for text stream
-        self.txt_mod = nn.Sequential(
-            nn.SiLU(),
-            AWQW4A16Linear(dim, 6 * dim, bias=True, torch_dtype=dtype, device=device),
-        )
+        self.txt_mod = nn.Sequential(nn.SiLU(), AWQW4A16Linear(dim, 6 * dim, bias=True, torch_dtype=dtype, device=device))
         self.txt_norm1 = operations.LayerNorm(dim, elementwise_affine=False, eps=eps, dtype=dtype, device=device)
         self.txt_norm2 = operations.LayerNorm(dim, elementwise_affine=False, eps=eps, dtype=dtype, device=device)
         self.txt_mlp = NunchakuFeedForward(dim=dim, dim_out=dim, dtype=dtype, device=device, **kwargs)
@@ -397,23 +261,6 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
         )
 
     def _modulate(self, x: torch.Tensor, mod_params: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        Apply modulation to input tensor.
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            Input tensor of shape (batch, seq_len, dim).
-        mod_params : torch.Tensor
-            Modulation parameters of shape (batch, 3*dim).
-
-        Returns
-        -------
-        modulated_x : torch.Tensor
-            Modulated tensor.
-        gate : torch.Tensor
-            Gate tensor for residual connection.
-        """
         shift, scale, gate = mod_params.chunk(3, dim=-1)
         if self.scale_shift != 0:
             scale.add_(self.scale_shift)
@@ -427,74 +274,38 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
         temb: torch.Tensor,
         image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        Forward pass for the transformer block.
 
-        Parameters
-        ----------
-        hidden_states : torch.Tensor
-            Image stream input tensor.
-        encoder_hidden_states : torch.Tensor
-            Text stream input tensor.
-        encoder_hidden_states_mask : torch.Tensor
-            Mask for encoder hidden states.
-        temb : torch.Tensor
-            Timestep or conditioning embedding.
-        image_rotary_emb : tuple of torch.Tensor, optional
-            Rotary positional embeddings.
+        img_mod_params = self.img_mod(temb)
+        txt_mod_params = self.txt_mod(temb)
 
-        Returns
-        -------
-        encoder_hidden_states : torch.Tensor
-            Updated text stream tensor.
-        hidden_states : torch.Tensor
-            Updated image stream tensor.
-        """
-        # Get modulation parameters for both streams
-        img_mod_params = self.img_mod(temb)  # [B, 6*dim]
-        txt_mod_params = self.txt_mod(temb)  # [B, 6*dim]
+        img_mod_params = img_mod_params.view(img_mod_params.shape[0], -1, 6).transpose(1, 2).reshape(img_mod_params.shape[0], -1)
+        txt_mod_params = txt_mod_params.view(txt_mod_params.shape[0], -1, 6).transpose(1, 2).reshape(txt_mod_params.shape[0], -1)
 
-        # Nunchaku's mod_params is [B, 6*dim] instead of [B, dim*6]
-        img_mod_params = (
-            img_mod_params.view(img_mod_params.shape[0], -1, 6).transpose(1, 2).reshape(img_mod_params.shape[0], -1)
-        )
-        txt_mod_params = (
-            txt_mod_params.view(txt_mod_params.shape[0], -1, 6).transpose(1, 2).reshape(txt_mod_params.shape[0], -1)
-        )
+        img_mod1, img_mod2 = img_mod_params.chunk(2, dim=-1)
+        txt_mod1, txt_mod2 = txt_mod_params.chunk(2, dim=-1)
 
-        img_mod1, img_mod2 = img_mod_params.chunk(2, dim=-1)  # Each [B, 3*dim]
-        txt_mod1, txt_mod2 = txt_mod_params.chunk(2, dim=-1)  # Each [B, 3*dim]
-
-        # Process image stream - norm1 + modulation
         img_normed = self.img_norm1(hidden_states)
         img_modulated, img_gate1 = self._modulate(img_normed, img_mod1)
 
-        # Process text stream - norm1 + modulation
         txt_normed = self.txt_norm1(encoder_hidden_states)
         txt_modulated, txt_gate1 = self._modulate(txt_normed, txt_mod1)
 
-        # Joint attention computation (DoubleStreamLayerMegatron logic)
-        attn_output = self.attn(
-            hidden_states=img_modulated,  # Image stream ("sample")
-            encoder_hidden_states=txt_modulated,  # Text stream ("context")
+        img_attn_output, txt_attn_output = self.attn(
+            hidden_states=img_modulated,
+            encoder_hidden_states=txt_modulated,
             encoder_hidden_states_mask=encoder_hidden_states_mask,
+            attention_mask=encoder_hidden_states_mask,
             image_rotary_emb=image_rotary_emb,
         )
 
-        # QwenAttnProcessor2_0 returns (img_output, txt_output) when encoder_hidden_states is provided
-        img_attn_output, txt_attn_output = attn_output
-
-        # Apply attention gates and add residual (like in Megatron)
         hidden_states = hidden_states + img_gate1 * img_attn_output
         encoder_hidden_states = encoder_hidden_states + txt_gate1 * txt_attn_output
 
-        # Process image stream - norm2 + MLP
         img_normed2 = self.img_norm2(hidden_states)
         img_modulated2, img_gate2 = self._modulate(img_normed2, img_mod2)
         img_mlp_output = self.img_mlp(img_modulated2)
         hidden_states = hidden_states + img_gate2 * img_mlp_output
 
-        # Process text stream - norm2 + MLP
         txt_normed2 = self.txt_norm2(encoder_hidden_states)
         txt_modulated2, txt_gate2 = self._modulate(txt_normed2, txt_mod2)
         txt_mlp_output = self.txt_mlp(txt_modulated2)
@@ -504,45 +315,6 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
 
 
 class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransformer2DModel):
-    """
-    Full transformer model for QwenImage, using Nunchaku-optimized blocks.
-
-    Parameters
-    ----------
-    patch_size : int, optional
-        Patch size for image input (default: 2).
-    in_channels : int, optional
-        Number of input channels (default: 64).
-    out_channels : int, optional
-        Number of output channels (default: 16).
-    num_layers : int, optional
-        Number of transformer layers (default: 60).
-    attention_head_dim : int, optional
-        Dimension per attention head (default: 128).
-    num_attention_heads : int, optional
-        Number of attention heads (default: 24).
-    joint_attention_dim : int, optional
-        Dimension for joint attention (default: 3584).
-    pooled_projection_dim : int, optional
-        Dimension for pooled projection (default: 768).
-    guidance_embeds : bool, optional
-        Whether to use guidance embeddings (default: False).
-    axes_dims_rope : tuple of int, optional
-        Axes dimensions for rotary embeddings (default: (16, 56, 56)).
-    image_model : module, optional
-        Optional image model.
-    dtype : torch.dtype, optional
-        Data type for projections.
-    device : torch.device, optional
-        Device for projections.
-    operations : module, optional
-        Module providing normalization and linear layers.
-    scale_shift : float, optional
-        Value added to scale in modulation (default: 1.0).
-    **kwargs
-        Additional arguments for quantized linear layers.
-    """
-
     def __init__(
         self,
         patch_size: int = 2,
@@ -598,63 +370,28 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
             ]
         )
 
-        self.norm_out = LastLayer(
-            self.inner_dim,
-            self.inner_dim,
-            dtype=dtype,
-            device=device,
-            operations=operations,
-        )
-        self.proj_out = operations.Linear(
-            self.inner_dim,
-            patch_size * patch_size * self.out_channels,
-            bias=True,
-            dtype=dtype,
-            device=device,
-        )
+        self.norm_out = LastLayer(self.inner_dim, self.inner_dim, dtype=dtype, device=device, operations=operations)
+        self.proj_out = operations.Linear(self.inner_dim, patch_size * patch_size * self.out_channels, bias=True, dtype=dtype, device=device)
         self.gradient_checkpointing = False
+
+        self.offload = False
+        self.offload_manager: Optional[CPUOffloadManager] = None
 
     def _forward(
         self,
-        x,
+        x: torch.Tensor,
         timesteps,
-        context,
-        attention_mask=None,
-        guidance: torch.Tensor = None,
+        context: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        guidance: Optional[torch.Tensor] = None,
         ref_latents=None,
-        transformer_options={},
+        transformer_options: Dict[str, Any] = {},
+        control: Optional[Dict[str, List[Optional[torch.Tensor]]]] = None,
         **kwargs,
-    ):
-        """
-        Forward pass of the Nunchaku Qwen-Image model.
+    ) -> torch.Tensor:
 
-        Parameters
-        ----------
-        x : torch.Tensor
-            Input image tensor of shape (batch, channels, height, width).
-        timesteps : torch.Tensor or int
-            Timestep(s) for diffusion process.
-        context : torch.Tensor
-            Textual context tensor (e.g., from a text encoder).
-        attention_mask : torch.Tensor, optional
-            Optional attention mask for the context.
-        guidance : torch.Tensor, optional
-            Optional guidance tensor for classifier-free guidance.
-        ref_latents : list[torch.Tensor], optional
-            Optional list of reference latent tensors for multi-image conditioning.
-        transformer_options : dict, optional
-            Dictionary of options for transformer block patching and replacement.
-        **kwargs
-            Additional keyword arguments. Supports 'ref_latents_method' to control reference latent handling.
-
-        Returns
-        -------
-        torch.Tensor
-            Output tensor of shape (batch, channels, height, width), matching the input spatial dimensions.
-
-        """
         device = x.device
-        if self.offload:
+        if self.offload and self.offload_manager is not None:
             self.offload_manager.set_device(device)
 
         timestep = timesteps
@@ -665,9 +402,7 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
         num_embeds = hidden_states.shape[1]
 
         if ref_latents is not None:
-            h = 0
-            w = 0
-            index = 0
+            h = w = index = 0
             index_ref_method = kwargs.get("ref_latents_method", "index") == "index"
             for ref in ref_latents:
                 if index_ref_method:
@@ -689,17 +424,9 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
                 hidden_states = torch.cat([hidden_states, kontext], dim=1)
                 img_ids = torch.cat([img_ids, kontext_ids], dim=1)
 
-        txt_start = round(
-            max(
-                ((x.shape[-1] + (self.patch_size // 2)) // self.patch_size) // 2,
-                ((x.shape[-2] + (self.patch_size // 2)) // self.patch_size) // 2,
-            )
-        )
-        txt_ids = (
-            torch.arange(txt_start, txt_start + context.shape[1], device=x.device)
-            .reshape(1, -1, 1)
-            .repeat(x.shape[0], 1, 3)
-        )
+        txt_start = round(max(((x.shape[-1] + (self.patch_size // 2)) // self.patch_size) // 2,
+                              ((x.shape[-2] + (self.patch_size // 2)) // self.patch_size) // 2))
+        txt_ids = torch.arange(txt_start, txt_start + context.shape[1], device=x.device).reshape(1, -1, 1).repeat(x.shape[0], 1, 3)
         ids = torch.cat((txt_ids, img_ids), dim=1)
         image_rotary_emb = self.pe_embedder(ids).squeeze(1).unsqueeze(2).to(x.dtype)
         del ids, txt_ids, img_ids
@@ -711,43 +438,90 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
         if guidance is not None:
             guidance = guidance * 1000
 
-        temb = (
-            self.time_text_embed(timestep, hidden_states)
-            if guidance is None
-            else self.time_text_embed(timestep, guidance, hidden_states)
-        )
+        temb = (self.time_text_embed(timestep, hidden_states) if guidance is None
+                else self.time_text_embed(timestep, guidance, hidden_states))
 
+        # ---- patches + control ----
         patches_replace = transformer_options.get("patches_replace", {})
-        blocks_replace = patches_replace.get("dit", {})
+        blocks_replace = {}
+        for k in ("dit", "qwen", "double_blocks", "blocks"):
+            v = patches_replace.get(k, {})
+            if isinstance(v, dict):
+                blocks_replace.update(v)
 
-        # Setup compute stream for offloading
+        if control is None:
+            control = kwargs.get("control", None)
+        if control is None:
+            control = transformer_options.get("control", None)
+
+        # Optional scale
+        try:
+            control_scale = float(control.get("weight", control.get("scale", 1.0))) if control is not None else 1.0
+        except Exception:
+            control_scale = 1.0
+
+        # Pre-get lists (may be None)
+        c_input_img = control.get("input", None) if isinstance(control, dict) else None
+        c_input_txt = control.get("input_txt", None) if isinstance(control, dict) else None
+        c_output_img = control.get("output", None) if isinstance(control, dict) else None
+        c_output_txt = control.get("output_txt", None) if isinstance(control, dict) else None
+
         compute_stream = torch.cuda.current_stream()
-        if self.offload:
+        if self.offload and self.offload_manager is not None:
             self.offload_manager.initialize(compute_stream)
+
+        num_layers = len(self.transformer_blocks)
 
         for i, block in enumerate(self.transformer_blocks):
             with torch.cuda.stream(compute_stream):
-                if self.offload:
+                if self.offload and self.offload_manager is not None:
                     block = self.offload_manager.get_block(i)
-                if ("double_block", i) in blocks_replace:
 
-                    def block_wrap(args):
-                        out = {}
-                        out["txt"], out["img"] = block(
-                            hidden_states=args["img"],
-                            encoder_hidden_states=args["txt"],
-                            encoder_hidden_states_mask=encoder_hidden_states_mask,
-                            temb=args["vec"],
-                            image_rotary_emb=args["pe"],
-                        )
-                        return out
+                # prepare patch args
+                args = {
+                    "img": hidden_states,
+                    "txt": encoder_hidden_states,
+                    "vec": temb,
+                    "pe": image_rotary_emb,
+                    "mask": encoder_hidden_states_mask,
+                    "block_index": i,
+                    "num_layers": num_layers,
+                    "timestep": timestep,
+                }
 
-                    out = blocks_replace[("double_block", i)](
-                        {"img": hidden_states, "txt": encoder_hidden_states, "vec": temb, "pe": image_rotary_emb},
-                        {"original_block": block_wrap},
+                def _orig(a):
+                    t_out, i_out = block(
+                        hidden_states=a.get("img", hidden_states),
+                        encoder_hidden_states=a.get("txt", encoder_hidden_states),
+                        encoder_hidden_states_mask=a.get("mask", encoder_hidden_states_mask),
+                        temb=a.get("vec", temb),
+                        image_rotary_emb=a.get("pe", image_rotary_emb),
                     )
-                    hidden_states = out["img"]
-                    encoder_hidden_states = out["txt"]
+                    return {"img": i_out, "txt": t_out}
+
+                patch_fn = (
+                    blocks_replace.get(("double_block", i), None)
+                    or blocks_replace.get(("block", i), None)
+                    or blocks_replace.get(i, None)
+                )
+
+                if patch_fn is not None:
+                    try:
+                        out = patch_fn(args, {"original_block": _orig})
+                    except TypeError:
+                        out = patch_fn(args)
+                    if isinstance(out, dict):
+                        hidden_states = out.get("img", hidden_states)
+                        encoder_hidden_states = out.get("txt", encoder_hidden_states)
+                    else:
+                        try:
+                            enc_out, img_out = out
+                            if img_out is not None:
+                                hidden_states = img_out
+                            if enc_out is not None:
+                                encoder_hidden_states = enc_out
+                        except Exception:
+                            pass
                 else:
                     encoder_hidden_states, hidden_states = block(
                         hidden_states=hidden_states,
@@ -756,7 +530,38 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
                         temb=temb,
                         image_rotary_emb=image_rotary_emb,
                     )
-            if self.offload:
+
+                # ---- ControlNet per-layer residuals (keep offload; align device/dtype non_blocking) ----
+                if c_input_img is not None and i < len(c_input_img):
+                    add = _to_dev_dtype(c_input_img[i], hidden_states)
+                    if add is not None:
+                        # crop to token overlap
+                        if add.dim() == 3 and hidden_states.dim() == 3 and add.shape[1] > hidden_states.shape[1]:
+                            add = add[:, :hidden_states.shape[1], :]
+                        _apply_residual(hidden_states, add, control_scale)
+
+                if c_input_txt is not None and i < len(c_input_txt):
+                    addt = _to_dev_dtype(c_input_txt[i], encoder_hidden_states)
+                    if addt is not None:
+                        if addt.dim() == 3 and encoder_hidden_states.dim() == 3 and addt.shape[1] > encoder_hidden_states.shape[1]:
+                            addt = addt[:, :encoder_hidden_states.shape[1], :]
+                        _apply_residual(encoder_hidden_states, addt, control_scale)
+
+                if c_output_img is not None and i < len(c_output_img):
+                    addo = _to_dev_dtype(c_output_img[i], hidden_states)
+                    if addo is not None:
+                        if addo.dim() == 3 and hidden_states.dim() == 3 and addo.shape[1] > hidden_states.shape[1]:
+                            addo = addo[:, :hidden_states.shape[1], :]
+                        _apply_residual(hidden_states, addo, control_scale)
+
+                if c_output_txt is not None and i < len(c_output_txt):
+                    addot = _to_dev_dtype(c_output_txt[i], encoder_hidden_states)
+                    if addot is not None:
+                        if addot.dim() == 3 and encoder_hidden_states.dim() == 3 and addot.shape[1] > encoder_hidden_states.shape[1]:
+                            addot = addot[:, :encoder_hidden_states.shape[1], :]
+                        _apply_residual(encoder_hidden_states, addot, control_scale)
+
+            if self.offload and self.offload_manager is not None:
                 self.offload_manager.step(compute_stream)
 
         hidden_states = self.norm_out(hidden_states, temb)
@@ -769,39 +574,14 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
         return hidden_states.reshape(orig_shape)[:, :, :, : x.shape[-2], : x.shape[-1]]
 
     def set_offload(self, offload: bool, **kwargs):
-        """
-        Enable or disable CPU offloading for the transformer blocks.
-
-        Parameters
-        ----------
-        offload : bool
-            If True, enable CPU offloading. If False, disable it.
-        **kwargs
-            Additional keyword arguments:
-                - use_pin_memory (bool): Whether to use pinned memory (default: True).
-                - num_blocks_on_gpu (int): Number of transformer blocks to keep on GPU (default: 1).
-
-        Notes
-        -----
-        - When offloading is enabled, only a subset of modules remain on GPU.
-        - When disabling, memory is released and CUDA cache is cleared.
-        """
-        if offload == self.offload:
-            # Nothing changed, just return
+        if offload == getattr(self, "offload", False):
             return
         self.offload = offload
         if offload:
             self.offload_manager = CPUOffloadManager(
                 self.transformer_blocks,
                 use_pin_memory=kwargs.get("use_pin_memory", True),
-                on_gpu_modules=[
-                    self.img_in,
-                    self.txt_in,
-                    self.txt_norm,
-                    self.time_text_embed,
-                    self.norm_out,
-                    self.proj_out,
-                ],
+                on_gpu_modules=[self.img_in, self.txt_in, self.txt_norm, self.time_text_embed, self.norm_out, self.proj_out],
                 num_blocks_on_gpu=kwargs.get("num_blocks_on_gpu", 1),
             )
         else:

--- a/models/qwenimage.py
+++ b/models/qwenimage.py
@@ -613,13 +613,13 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
             dtype=dtype,
             device=device,
         )
-        self.gradient_checkpointing = False
-
-    # Forward wrapper: explicitly pass `control` to `_forward` (mirrors ComfyUI qwen_image/model.py)
-
+        self.gradient_checkpointing = False    # Forward wrapper: explicitly pass `control` to `_forward` (mirrors ComfyUI qwen_image/model.py)
     def forward(self, x, timesteps, context, attention_mask=None, guidance=None, ref_latents=None, transformer_options={}, control=None, **kwargs):
-
-        return comfy.patcher_extension.WrapperExecutor.new_class_executor(self._forward, self, comfy.patcher_extension.get_all_wrappers(comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options)).execute(x, timesteps, context, attention_mask, guidance, ref_latents, transformer_options, control, **kwargs)
+        return comfy.patcher_extension.WrapperExecutor.new_class_executor(
+            self._forward, self, comfy.patcher_extension.get_all_wrappers(
+                comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options),
+        ).execute(x, timesteps, context, attention_mask, guidance, ref_latents, transformer_options,
+                  control, **kwargs)
 
 
     def _forward(
@@ -766,7 +766,11 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
                         image_rotary_emb=image_rotary_emb,
                     )
                 # ControlNet helpers(device/dtype-safe residual adds)
-                _control = control if control is not None else (transformer_options.get("control", None) if isinstance(transformer_options, dict) else None)
+                _control = (
+                    control
+                    if control is not None
+                    else (transformer_options.get("control", None) if isinstance(transformer_options, dict) else None)
+                )
                 if isinstance(_control, dict):
                     control_i = _control.get("input")
                     try:
@@ -779,7 +783,10 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
                 if control_i is not None and i < len(control_i):
                     add = control_i[i]
                     if add is not None:
-                        if getattr(add, 'device', None) != hidden_states.device or getattr(add, 'dtype', None) != hidden_states.dtype:
+                        if (
+                            getattr(add, "device", None) != hidden_states.device
+                            or getattr(add, "dtype", None) != hidden_states.dtype
+                        ):
                             add = add.to(device=hidden_states.device, dtype=hidden_states.dtype, non_blocking=True)
                         t = min(hidden_states.shape[1], add.shape[1])
                         if t > 0:

--- a/models/qwenimage.py
+++ b/models/qwenimage.py
@@ -1,30 +1,17 @@
-
-# -*- coding: utf-8 -*-
 """
-Nunchaku Qwen-Image — minimal sampler & ControlNet device alignment fix
+This module implements the Nunchaku Qwen-Image model and related components.
 
-This file is a drop-in replacement for:
-custom_nodes/ComfyUI-nunchaku/models/qwenimage.py
+.. note::
 
-What changed (smallest possible surface):
-1) Before calling each transformer block, we align `hidden_states`, `encoder_hidden_states`,
-   `temb`, `encoder_hidden_states_mask`, and `image_rotary_emb` to the block's *current* device.
-   This fixes device mismatches seen with RES4LYF enhanced sampler and built-in samplers
-   when CPU offload is enabled.
-2) Control residuals (input/output, img/txt) are added with device/dtype-safe helpers
-   and cropped to token overlap if lengths differ. No behavior change otherwise.
-3) No signature changes; class names and attributes preserved.
-
-If you previously used my "修复cn" variant under model_base/, this file integrates the same
-safe residual adds and alignment logic here to keep your directory layout intact.
+    Inherits and modifies from https://github.com/comfyanonymous/ComfyUI/blob/v0.3.51/comfy/ldm/qwen_image/model.py
 """
 
-from typing import Optional, Tuple, Dict, Any, List
+import gc
+from typing import Optional, Tuple
 
 import torch
-from torch import nn
-
 from comfy.ldm.flux.layers import EmbedND
+from comfy.ldm.modules.attention import optimized_attention_masked
 from comfy.ldm.qwen_image.model import (
     GELU,
     FeedForward,
@@ -33,6 +20,7 @@ from comfy.ldm.qwen_image.model import (
     QwenTimestepProjEmbeddings,
     apply_rotary_emb,
 )
+from torch import nn
 
 from nunchaku.models.linear import AWQW4A16Linear, SVDQW4A4Linear
 from nunchaku.models.utils import CPUOffloadManager
@@ -40,29 +28,30 @@ from nunchaku.ops.fused import fused_gelu_mlp
 
 from ..mixins.model import NunchakuModelMixin
 
+# ---------- ControlNet helpers (device/dtype-safe residual adds) ----------
 
-# ---------- helpers ----------
 def _to_dev_dtype(t: Optional[torch.Tensor], ref: torch.Tensor) -> Optional[torch.Tensor]:
+    """Move tensor to ref's device/dtype if needed (non_blocking when possible)."""
     if t is None or not isinstance(t, torch.Tensor):
         return None
     if t.device == ref.device and t.dtype == ref.dtype:
         return t
-    # non_blocking=True if source in pinned memory; harmless otherwise
     return t.to(device=ref.device, dtype=ref.dtype, non_blocking=True)
 
 
 def _apply_residual(base: torch.Tensor, resid: Optional[torch.Tensor], scale: float = 1.0) -> torch.Tensor:
+    """Safely add residual to base (handles broadcast + token-length overlap)."""
     if resid is None:
         return base
-    if resid.numel() == 0:
+    if not isinstance(resid, torch.Tensor) or resid.numel() == 0:
         return base
-    # Try fast broadcast first
+    # Try fast in-place add first
     try:
         base.add_(resid, alpha=scale)
         return base
     except Exception:
         pass
-    # If sequence lengths differ, add overlap only
+    # Overlap on sequence length if shapes differ
     if base.dim() == 3 and resid.dim() == 3 and base.shape[0] == resid.shape[0] and base.shape[2] == resid.shape[2]:
         b, sb, d = base.shape
         _, sr, _ = resid.shape
@@ -81,15 +70,71 @@ def _apply_residual(base: torch.Tensor, resid: Optional[torch.Tensor], scale: fl
     return base
 
 
-# ---------- quantized layers ----------
+
+
 class NunchakuGELU(GELU):
-    def __init__(self, dim_in: int, dim_out: int, approximate: str = "none", bias: bool = True, dtype=None, device=None, **kwargs):
+    """
+    GELU activation with a quantized linear projection.
+
+    Parameters
+    ----------
+    dim_in : int
+        Input feature dimension.
+    dim_out : int
+        Output feature dimension.
+    approximate : str, optional
+        Approximation mode for GELU (default: "none").
+    bias : bool, optional
+        Whether to use bias in the projection (default: True).
+    dtype : torch.dtype, optional
+        Data type for the projection.
+    device : torch.device, optional
+        Device for the projection.
+    **kwargs
+        Additional arguments for the quantized linear layer.
+    """
+
+    def __init__(
+        self,
+        dim_in: int,
+        dim_out: int,
+        approximate: str = "none",
+        bias: bool = True,
+        dtype=None,
+        device=None,
+        **kwargs,
+    ):
         super(GELU, self).__init__()
         self.proj = SVDQW4A4Linear(dim_in, dim_out, bias=bias, torch_dtype=dtype, device=device, **kwargs)
         self.approximate = approximate
 
 
 class NunchakuFeedForward(FeedForward):
+    """
+    Feed-forward network with fused quantized layers and optional fused GELU-MLP.
+
+    Parameters
+    ----------
+    dim : int
+        Input feature dimension.
+    dim_out : int, optional
+        Output feature dimension. If None, set to `dim`.
+    mult : int, optional
+        Expansion factor for the hidden layer (default: 4).
+    dropout : float, optional
+        Dropout probability (default: 0.0).
+    inner_dim : int, optional
+        Hidden layer dimension. If None, computed as `dim * mult`.
+    bias : bool, optional
+        Whether to use bias in the projections (default: True).
+    dtype : torch.dtype, optional
+        Data type for the projections.
+    device : torch.device, optional
+        Device for the projections.
+    **kwargs
+        Additional arguments for the quantized linear layers.
+    """
+
     def __init__(
         self,
         dim: int,
@@ -108,14 +153,17 @@ class NunchakuFeedForward(FeedForward):
         dim_out = dim_out if dim_out is not None else dim
 
         self.net = nn.ModuleList([])
-        self.net.append(NunchakuGELU(dim, inner_dim, approximate="tanh", bias=bias, dtype=dtype, device=device, **kwargs))
+        self.net.append(
+            NunchakuGELU(dim, inner_dim, approximate="tanh", bias=bias, dtype=dtype, device=device, **kwargs)
+        )
         self.net.append(nn.Dropout(dropout))
         self.net.append(
             SVDQW4A4Linear(
                 inner_dim,
                 dim_out,
                 bias=bias,
-                act_unsigned=kwargs.get("precision", None) == "int4",
+                act_unsigned=kwargs["precision"]
+                == "int4",  # For int4 quantization, the second linear layer is unsigned as the output of the first is shifted positive in fused_gelu_mlp
                 torch_dtype=dtype,
                 device=device,
                 **kwargs,
@@ -123,14 +171,65 @@ class NunchakuFeedForward(FeedForward):
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for the feed-forward network.
+
+        Parameters
+        ----------
+        hidden_states : torch.Tensor
+            Input tensor of shape (batch, seq_len, dim).
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor after feed-forward transformation.
+        """
         if isinstance(self.net[0], NunchakuGELU):
             return fused_gelu_mlp(hidden_states, self.net[0].proj, self.net[2])
-        for module in self.net:
-            hidden_states = module(hidden_states)
-        return hidden_states
+        else:
+            # Fallback to original implementation
+            for module in self.net:
+                hidden_states = module(hidden_states)
+            return hidden_states
 
 
 class Attention(nn.Module):
+    """
+    Double-stream attention module for joint image-text attention.
+
+    This module fuses QKV projections for both image and text streams for improved speed,
+    applies Q/K normalization and rotary embeddings, and computes joint attention.
+
+    Parameters
+    ----------
+    query_dim : int
+        Input feature dimension.
+    dim_head : int, optional
+        Dimension per attention head (default: 64).
+    heads : int, optional
+        Number of attention heads (default: 8).
+    dropout : float, optional
+        Dropout probability (default: 0.0).
+    bias : bool, optional
+        Whether to use bias in projections (default: False).
+    eps : float, optional
+        Epsilon for normalization layers (default: 1e-5).
+    out_bias : bool, optional
+        Whether to use bias in output projections (default: True).
+    out_dim : int, optional
+        Output dimension for image stream.
+    out_context_dim : int, optional
+        Output dimension for text stream.
+    dtype : torch.dtype, optional
+        Data type for projections.
+    device : torch.device, optional
+        Device for projections.
+    operations : module, optional
+        Module providing normalization and linear layers.
+    **kwargs
+        Additional arguments for quantized linear layers.
+    """
+
     def __init__(
         self,
         query_dim: int,
@@ -156,19 +255,32 @@ class Attention(nn.Module):
         self.out_context_dim = out_context_dim if out_context_dim is not None else query_dim
         self.dropout = dropout
 
+        # Q/K normalization for both streams
         self.norm_q = operations.RMSNorm(dim_head, eps=eps, elementwise_affine=True, dtype=dtype, device=device)
         self.norm_k = operations.RMSNorm(dim_head, eps=eps, elementwise_affine=True, dtype=dtype, device=device)
         self.norm_added_q = operations.RMSNorm(dim_head, eps=eps, dtype=dtype, device=device)
         self.norm_added_k = operations.RMSNorm(dim_head, eps=eps, dtype=dtype, device=device)
 
-        self.to_qkv = SVDQW4A4Linear(query_dim, self.inner_dim + self.inner_kv_dim * 2, bias=bias, torch_dtype=dtype, device=device, **kwargs)
-        self.add_qkv_proj = SVDQW4A4Linear(query_dim, self.inner_dim + self.inner_kv_dim * 2, bias=bias, torch_dtype=dtype, device=device, **kwargs)
+        # Image stream projections: fused QKV for speed
+        self.to_qkv = SVDQW4A4Linear(
+            query_dim, self.inner_dim + self.inner_kv_dim * 2, bias=bias, torch_dtype=dtype, device=device, **kwargs
+        )
 
-        self.to_out = nn.ModuleList([
-            SVDQW4A4Linear(self.inner_dim, self.out_dim, bias=out_bias, torch_dtype=dtype, device=device, **kwargs),
-            nn.Dropout(dropout),
-        ])
-        self.to_add_out = SVDQW4A4Linear(self.inner_dim, self.out_context_dim, bias=out_bias, torch_dtype=dtype, device=device, **kwargs)
+        # Text stream projections: fused QKV for speed
+        self.add_qkv_proj = SVDQW4A4Linear(
+            query_dim, self.inner_dim + self.inner_kv_dim * 2, bias=bias, torch_dtype=dtype, device=device, **kwargs
+        )
+
+        # Output projections
+        self.to_out = nn.ModuleList(
+            [
+                SVDQW4A4Linear(self.inner_dim, self.out_dim, bias=out_bias, torch_dtype=dtype, device=device, **kwargs),
+                nn.Dropout(dropout),
+            ]
+        )
+        self.to_add_out = SVDQW4A4Linear(
+            self.inner_dim, self.out_context_dim, bias=out_bias, torch_dtype=dtype, device=device, **kwargs
+        )
 
     def forward(
         self,
@@ -178,12 +290,35 @@ class Attention(nn.Module):
         attention_mask: Optional[torch.FloatTensor] = None,
         image_rotary_emb: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Forward pass for double-stream attention.
 
+        Parameters
+        ----------
+        hidden_states : torch.FloatTensor
+            Image stream input tensor of shape (batch, seq_len_img, dim).
+        encoder_hidden_states : torch.FloatTensor, optional
+            Text stream input tensor of shape (batch, seq_len_txt, dim).
+        encoder_hidden_states_mask : torch.FloatTensor, optional
+            Mask for encoder hidden states.
+        attention_mask : torch.FloatTensor, optional
+            Attention mask for joint attention.
+        image_rotary_emb : torch.Tensor, optional
+            Rotary positional embeddings.
+
+        Returns
+        -------
+        img_attn_output : torch.Tensor
+            Output tensor for image stream.
+        txt_attn_output : torch.Tensor
+            Output tensor for text stream.
+        """
         seq_txt = encoder_hidden_states.shape[1]
 
         img_qkv = self.to_qkv(hidden_states)
         img_query, img_key, img_value = img_qkv.chunk(3, dim=-1)
 
+        # Compute QKV for text stream (context projections)
         txt_qkv = self.add_qkv_proj(encoder_hidden_states)
         txt_query, txt_key, txt_value = txt_qkv.chunk(3, dim=-1)
 
@@ -200,10 +335,12 @@ class Attention(nn.Module):
         txt_query = self.norm_added_q(txt_query)
         txt_key = self.norm_added_k(txt_key)
 
+        # Concatenate image and text streams for joint attention
         joint_query = torch.cat([txt_query, img_query], dim=1)
         joint_key = torch.cat([txt_key, img_key], dim=1)
         joint_value = torch.cat([txt_value, img_value], dim=1)
 
+        # Apply rotary embeddings
         joint_query = apply_rotary_emb(joint_query, image_rotary_emb)
         joint_key = apply_rotary_emb(joint_key, image_rotary_emb)
 
@@ -211,9 +348,12 @@ class Attention(nn.Module):
         joint_key = joint_key.flatten(start_dim=2)
         joint_value = joint_value.flatten(start_dim=2)
 
-        from comfy.ldm.modules.attention import optimized_attention_masked
-        joint_hidden_states = optimized_attention_masked(joint_query, joint_key, joint_value, self.heads, attention_mask)
+        # Compute joint attention
+        joint_hidden_states = optimized_attention_masked(
+            joint_query, joint_key, joint_value, self.heads, attention_mask
+        )
 
+        # Split results back to separate streams
         txt_attn_output = joint_hidden_states[:, :seq_txt, :]
         img_attn_output = joint_hidden_states[:, seq_txt:, :]
 
@@ -225,6 +365,31 @@ class Attention(nn.Module):
 
 
 class NunchakuQwenImageTransformerBlock(nn.Module):
+    """
+    Transformer block with dual-stream (image/text) processing, modulation, and quantized attention/MLP.
+
+    Parameters
+    ----------
+    dim : int
+        Input feature dimension.
+    num_attention_heads : int
+        Number of attention heads.
+    attention_head_dim : int
+        Dimension per attention head.
+    eps : float, optional
+        Epsilon for normalization layers (default: 1e-6).
+    dtype : torch.dtype, optional
+        Data type for projections.
+    device : torch.device, optional
+        Device for projections.
+    operations : module, optional
+        Module providing normalization and linear layers.
+    scale_shift : float, optional
+        Value added to scale in modulation (default: 1.0). Nunchaku may have fused the scale's shift into bias.
+    **kwargs
+        Additional arguments for quantized linear layers.
+    """
+
     def __init__(
         self,
         dim: int,
@@ -243,12 +408,20 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
         self.num_attention_heads = num_attention_heads
         self.attention_head_dim = attention_head_dim
 
-        self.img_mod = nn.Sequential(nn.SiLU(), AWQW4A16Linear(dim, 6 * dim, bias=True, torch_dtype=dtype, device=device))
+        # Modulation and normalization for image stream
+        self.img_mod = nn.Sequential(
+            nn.SiLU(),
+            AWQW4A16Linear(dim, 6 * dim, bias=True, torch_dtype=dtype, device=device),
+        )
         self.img_norm1 = operations.LayerNorm(dim, elementwise_affine=False, eps=eps, dtype=dtype, device=device)
         self.img_norm2 = operations.LayerNorm(dim, elementwise_affine=False, eps=eps, dtype=dtype, device=device)
         self.img_mlp = NunchakuFeedForward(dim=dim, dim_out=dim, dtype=dtype, device=device, **kwargs)
 
-        self.txt_mod = nn.Sequential(nn.SiLU(), AWQW4A16Linear(dim, 6 * dim, bias=True, torch_dtype=dtype, device=device))
+        # Modulation and normalization for text stream
+        self.txt_mod = nn.Sequential(
+            nn.SiLU(),
+            AWQW4A16Linear(dim, 6 * dim, bias=True, torch_dtype=dtype, device=device),
+        )
         self.txt_norm1 = operations.LayerNorm(dim, elementwise_affine=False, eps=eps, dtype=dtype, device=device)
         self.txt_norm2 = operations.LayerNorm(dim, elementwise_affine=False, eps=eps, dtype=dtype, device=device)
         self.txt_mlp = NunchakuFeedForward(dim=dim, dim_out=dim, dtype=dtype, device=device, **kwargs)
@@ -267,6 +440,23 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
         )
 
     def _modulate(self, x: torch.Tensor, mod_params: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Apply modulation to input tensor.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape (batch, seq_len, dim).
+        mod_params : torch.Tensor
+            Modulation parameters of shape (batch, 3*dim).
+
+        Returns
+        -------
+        modulated_x : torch.Tensor
+            Modulated tensor.
+        gate : torch.Tensor
+            Gate tensor for residual connection.
+        """
         shift, scale, gate = mod_params.chunk(3, dim=-1)
         if self.scale_shift != 0:
             scale.add_(self.scale_shift)
@@ -280,38 +470,75 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
         temb: torch.Tensor,
         image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Forward pass for the transformer block.
 
-        img_mod_params = self.img_mod(temb)
-        txt_mod_params = self.txt_mod(temb)
+        Parameters
+        ----------
+        hidden_states : torch.Tensor
+            Image stream input tensor.
+        encoder_hidden_states : torch.Tensor
+            Text stream input tensor.
+        encoder_hidden_states_mask : torch.Tensor
+            Mask for encoder hidden states.
+        temb : torch.Tensor
+            Timestep or conditioning embedding.
+        image_rotary_emb : tuple of torch.Tensor, optional
+            Rotary positional embeddings.
 
-        img_mod_params = img_mod_params.view(img_mod_params.shape[0], -1, 6).transpose(1, 2).reshape(img_mod_params.shape[0], -1)
-        txt_mod_params = txt_mod_params.view(txt_mod_params.shape[0], -1, 6).transpose(1, 2).reshape(txt_mod_params.shape[0], -1)
+        Returns
+        -------
+        encoder_hidden_states : torch.Tensor
+            Updated text stream tensor.
+        hidden_states : torch.Tensor
+            Updated image stream tensor.
+        """
+        # Get modulation parameters for both streams
+        img_mod_params = self.img_mod(temb)  # [B, 6*dim]
+        txt_mod_params = self.txt_mod(temb)  # [B, 6*dim]
 
-        img_mod1, img_mod2 = img_mod_params.chunk(2, dim=-1)
-        txt_mod1, txt_mod2 = txt_mod_params.chunk(2, dim=-1)
+        # Nunchaku's mod_params is [B, 6*dim] instead of [B, dim*6]
+        img_mod_params = (
+            img_mod_params.view(img_mod_params.shape[0], -1, 6).transpose(1, 2).reshape(img_mod_params.shape[0], -1)
+        )
+        txt_mod_params = (
+            txt_mod_params.view(txt_mod_params.shape[0], -1, 6).transpose(1, 2).reshape(txt_mod_params.shape[0], -1)
+        )
 
+        img_mod1, img_mod2 = img_mod_params.chunk(2, dim=-1)  # Each [B, 3*dim]
+        txt_mod1, txt_mod2 = txt_mod_params.chunk(2, dim=-1)  # Each [B, 3*dim]
+
+        # Process image stream - norm1 + modulation
         img_normed = self.img_norm1(hidden_states)
         img_modulated, img_gate1 = self._modulate(img_normed, img_mod1)
 
+        # Process text stream - norm1 + modulation
         txt_normed = self.txt_norm1(encoder_hidden_states)
         txt_modulated, txt_gate1 = self._modulate(txt_normed, txt_mod1)
 
-        img_attn_output, txt_attn_output = self.attn(
-            hidden_states=img_modulated,
-            encoder_hidden_states=txt_modulated,
+        # Joint attention computation (DoubleStreamLayerMegatron logic)
+        attn_output = self.attn(
+            hidden_states=img_modulated,  # Image stream ("sample")
+            encoder_hidden_states=txt_modulated,  # Text stream ("context")
             encoder_hidden_states_mask=encoder_hidden_states_mask,
             attention_mask=encoder_hidden_states_mask,
             image_rotary_emb=image_rotary_emb,
         )
 
+        # QwenAttnProcessor2_0 returns (img_output, txt_output) when encoder_hidden_states is provided
+        img_attn_output, txt_attn_output = attn_output
+
+        # Apply attention gates and add residual (like in Megatron)
         hidden_states = hidden_states + img_gate1 * img_attn_output
         encoder_hidden_states = encoder_hidden_states + txt_gate1 * txt_attn_output
 
+        # Process image stream - norm2 + MLP
         img_normed2 = self.img_norm2(hidden_states)
         img_modulated2, img_gate2 = self._modulate(img_normed2, img_mod2)
         img_mlp_output = self.img_mlp(img_modulated2)
         hidden_states = hidden_states + img_gate2 * img_mlp_output
 
+        # Process text stream - norm2 + MLP
         txt_normed2 = self.txt_norm2(encoder_hidden_states)
         txt_modulated2, txt_gate2 = self._modulate(txt_normed2, txt_mod2)
         txt_mlp_output = self.txt_mlp(txt_modulated2)
@@ -321,6 +548,45 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
 
 
 class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransformer2DModel):
+    """
+    Full transformer model for QwenImage, using Nunchaku-optimized blocks.
+
+    Parameters
+    ----------
+    patch_size : int, optional
+        Patch size for image input (default: 2).
+    in_channels : int, optional
+        Number of input channels (default: 64).
+    out_channels : int, optional
+        Number of output channels (default: 16).
+    num_layers : int, optional
+        Number of transformer layers (default: 60).
+    attention_head_dim : int, optional
+        Dimension per attention head (default: 128).
+    num_attention_heads : int, optional
+        Number of attention heads (default: 24).
+    joint_attention_dim : int, optional
+        Dimension for joint attention (default: 3584).
+    pooled_projection_dim : int, optional
+        Dimension for pooled projection (default: 768).
+    guidance_embeds : bool, optional
+        Whether to use guidance embeddings (default: False).
+    axes_dims_rope : tuple of int, optional
+        Axes dimensions for rotary embeddings (default: (16, 56, 56)).
+    image_model : module, optional
+        Optional image model.
+    dtype : torch.dtype, optional
+        Data type for projections.
+    device : torch.device, optional
+        Device for projections.
+    operations : module, optional
+        Module providing normalization and linear layers.
+    scale_shift : float, optional
+        Value added to scale in modulation (default: 1.0).
+    **kwargs
+        Additional arguments for quantized linear layers.
+    """
+
     def __init__(
         self,
         patch_size: int = 2,
@@ -376,28 +642,63 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
             ]
         )
 
-        self.norm_out = LastLayer(self.inner_dim, self.inner_dim, dtype=dtype, device=device, operations=operations)
-        self.proj_out = operations.Linear(self.inner_dim, patch_size * patch_size * self.out_channels, bias=True, dtype=dtype, device=device)
+        self.norm_out = LastLayer(
+            self.inner_dim,
+            self.inner_dim,
+            dtype=dtype,
+            device=device,
+            operations=operations,
+        )
+        self.proj_out = operations.Linear(
+            self.inner_dim,
+            patch_size * patch_size * self.out_channels,
+            bias=True,
+            dtype=dtype,
+            device=device,
+        )
         self.gradient_checkpointing = False
-
-        self.offload = False
-        self.offload_manager: Optional[CPUOffloadManager] = None
 
     def _forward(
         self,
-        x: torch.Tensor,
+        x,
         timesteps,
-        context: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        guidance: Optional[torch.Tensor] = None,
+        context,
+        attention_mask=None,
+        guidance: torch.Tensor = None,
         ref_latents=None,
-        transformer_options: Dict[str, Any] = {},
-        control: Optional[Dict[str, List[Optional[torch.Tensor]]]] = None,
+        transformer_options={},
         **kwargs,
-    ) -> torch.Tensor:
+    ):
+        """
+        Forward pass of the Nunchaku Qwen-Image model.
 
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input image tensor of shape (batch, channels, height, width).
+        timesteps : torch.Tensor or int
+            Timestep(s) for diffusion process.
+        context : torch.Tensor
+            Textual context tensor (e.g., from a text encoder).
+        attention_mask : torch.Tensor, optional
+            Optional attention mask for the context.
+        guidance : torch.Tensor, optional
+            Optional guidance tensor for classifier-free guidance.
+        ref_latents : list[torch.Tensor], optional
+            Optional list of reference latent tensors for multi-image conditioning.
+        transformer_options : dict, optional
+            Dictionary of options for transformer block patching and replacement.
+        **kwargs
+            Additional keyword arguments. Supports 'ref_latents_method' to control reference latent handling.
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor of shape (batch, channels, height, width), matching the input spatial dimensions.
+
+        """
         device = x.device
-        if self.offload and self.offload_manager is not None:
+        if self.offload:
             self.offload_manager.set_device(device)
 
         timestep = timesteps
@@ -408,7 +709,9 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
         num_embeds = hidden_states.shape[1]
 
         if ref_latents is not None:
-            h = w = index = 0
+            h = 0
+            w = 0
+            index = 0
             index_ref_method = kwargs.get("ref_latents_method", "index") == "index"
             for ref in ref_latents:
                 if index_ref_method:
@@ -430,9 +733,17 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
                 hidden_states = torch.cat([hidden_states, kontext], dim=1)
                 img_ids = torch.cat([img_ids, kontext_ids], dim=1)
 
-        txt_start = round(max(((x.shape[-1] + (self.patch_size // 2)) // self.patch_size) // 2,
-                              ((x.shape[-2] + (self.patch_size // 2)) // self.patch_size) // 2))
-        txt_ids = torch.arange(txt_start, txt_start + context.shape[1], device=x.device).reshape(1, -1, 1).repeat(x.shape[0], 1, 3)
+        txt_start = round(
+            max(
+                ((x.shape[-1] + (self.patch_size // 2)) // self.patch_size) // 2,
+                ((x.shape[-2] + (self.patch_size // 2)) // self.patch_size) // 2,
+            )
+        )
+        txt_ids = (
+            torch.arange(txt_start, txt_start + context.shape[1], device=x.device)
+            .reshape(1, -1, 1)
+            .repeat(x.shape[0], 1, 3)
+        )
         ids = torch.cat((txt_ids, img_ids), dim=1)
         image_rotary_emb = self.pe_embedder(ids).squeeze(1).unsqueeze(2).to(x.dtype)
         del ids, txt_ids, img_ids
@@ -444,146 +755,100 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
         if guidance is not None:
             guidance = guidance * 1000
 
-        temb = (self.time_text_embed(timestep, hidden_states) if guidance is None
-                else self.time_text_embed(timestep, guidance, hidden_states))
+        temb = (
+            self.time_text_embed(timestep, hidden_states)
+            if guidance is None
+            else self.time_text_embed(timestep, guidance, hidden_states)
+        )
 
-        # ---- patches + control ----
-        patches_replace = transformer_options.get("patches_replace", {})
-        blocks_replace = {}
-        for k in ("dit", "qwen", "double_blocks", "blocks"):
-            v = patches_replace.get(k, {})
-            if isinstance(v, dict):
-                blocks_replace.update(v)
-
-        if control is None:
-            control = kwargs.get("control", None)
+        # ---- ControlNet config (optional) ----
+        control = kwargs.get("control", None)
         if control is None:
             control = transformer_options.get("control", None)
-
-        # Optional scale
         try:
-            control_scale = float(control.get("weight", control.get("scale", 1.0))) if control is not None else 1.0
+            control_scale = float(control.get("weight", control.get("scale", 1.0))) if isinstance(control, dict) else 1.0
         except Exception:
             control_scale = 1.0
-
-        # Pre-get lists (may be None)
         c_input_img = control.get("input", None) if isinstance(control, dict) else None
         c_input_txt = control.get("input_txt", None) if isinstance(control, dict) else None
         c_output_img = control.get("output", None) if isinstance(control, dict) else None
         c_output_txt = control.get("output_txt", None) if isinstance(control, dict) else None
 
+        patches_replace = transformer_options.get("patches_replace", {})
+        blocks_replace = {}
+        for _k in ("dit", "qwen", "double_blocks", "blocks"):
+            _v = patches_replace.get(_k, {})
+            if isinstance(_v, dict):
+                blocks_replace.update(_v)
+
+        # Setup compute stream for offloading
         compute_stream = torch.cuda.current_stream()
-        if self.offload and self.offload_manager is not None:
+        if self.offload:
             self.offload_manager.initialize(compute_stream)
 
-        num_layers = len(self.transformer_blocks)
-
         for i, block in enumerate(self.transformer_blocks):
-            # ----- NEW: align inputs to current block device (fixes RMSNorm addmm device mismatches) -----
-            if self.offload and self.offload_manager is not None:
-                block = self.offload_manager.get_block(i)
+            with torch.cuda.stream(compute_stream):
+                if self.offload:
+                    block = self.offload_manager.get_block(i)
+                if ("double_block", i) in blocks_replace:
 
-            try:
-                module_device = next(block.parameters()).device
-            except StopIteration:
-                module_device = hidden_states.device
+                    def block_wrap(args):
+                        out = {}
+                        out["txt"], out["img"] = block(
+                            hidden_states=args["img"],
+                            encoder_hidden_states=args["txt"],
+                            encoder_hidden_states_mask=encoder_hidden_states_mask,
+                            temb=args["vec"],
+                            image_rotary_emb=args["pe"],
+                        )
+                        return out
 
-            if hidden_states.device != module_device:
-                hidden_states = hidden_states.to(module_device, non_blocking=True)
-            if encoder_hidden_states.device != module_device:
-                encoder_hidden_states = encoder_hidden_states.to(module_device, non_blocking=True)
-            if temb.device != module_device:
-                temb = temb.to(module_device, non_blocking=True)
-            if encoder_hidden_states_mask is not None and encoder_hidden_states_mask.device != module_device:
-                encoder_hidden_states_mask = encoder_hidden_states_mask.to(module_device, non_blocking=True)
-            if image_rotary_emb is not None and image_rotary_emb.device != module_device:
-                image_rotary_emb = image_rotary_emb.to(module_device, non_blocking=True)
-
-            # prepare patch args
-            args = {
-                "img": hidden_states,
-                "txt": encoder_hidden_states,
-                "vec": temb,
-                "pe": image_rotary_emb,
-                "mask": encoder_hidden_states_mask,
-                "block_index": i,
-                "num_layers": num_layers,
-                "timestep": timestep,
-            }
-
-            def _orig(a):
-                t_out, i_out = block(
-                    hidden_states=a.get("img", hidden_states),
-                    encoder_hidden_states=a.get("txt", encoder_hidden_states),
-                    encoder_hidden_states_mask=a.get("mask", encoder_hidden_states_mask),
-                    temb=a.get("vec", temb),
-                    image_rotary_emb=a.get("pe", image_rotary_emb),
-                )
-                return {"img": i_out, "txt": t_out}
-
-            patch_fn = (
-                blocks_replace.get(("double_block", i), None)
-                or blocks_replace.get(("block", i), None)
-                or blocks_replace.get(i, None)
-            )
-
-            if patch_fn is not None:
-                try:
-                    out = patch_fn(args, {"original_block": _orig})
-                except TypeError:
-                    out = patch_fn(args)
-                if isinstance(out, dict):
-                    hidden_states = out.get("img", hidden_states)
-                    encoder_hidden_states = out.get("txt", encoder_hidden_states)
+                    out = blocks_replace[("double_block", i)](
+                        {"img": hidden_states, "txt": encoder_hidden_states, "vec": temb, "pe": image_rotary_emb},
+                        {"original_block": block_wrap},
+                    )
+                    hidden_states = out["img"]
+                    encoder_hidden_states = out["txt"]
                 else:
-                    try:
-                        enc_out, img_out = out
-                        if img_out is not None:
-                            hidden_states = img_out
-                        if enc_out is not None:
-                            encoder_hidden_states = enc_out
-                    except Exception:
-                        pass
-            else:
-                encoder_hidden_states, hidden_states = block(
-                    hidden_states=hidden_states,
-                    encoder_hidden_states=encoder_hidden_states,
-                    encoder_hidden_states_mask=encoder_hidden_states_mask,
-                    temb=temb,
-                    image_rotary_emb=image_rotary_emb,
-                )
+                    encoder_hidden_states, hidden_states = block(
+                        hidden_states=hidden_states,
+                        encoder_hidden_states=encoder_hidden_states,
+                        encoder_hidden_states_mask=encoder_hidden_states_mask,
+                        temb=temb,
+                        image_rotary_emb=image_rotary_emb,
+                    )
 
-            # ---- ControlNet per-layer residuals (device/dtype aligned; token-overlap safe) ----
-            if c_input_img is not None and i < len(c_input_img):
-                add = _to_dev_dtype(c_input_img[i], hidden_states)
-                if add is not None:
-                    if add.dim() == 3 and hidden_states.dim() == 3 and add.shape[1] > hidden_states.shape[1]:
-                        add = add[:, :hidden_states.shape[1], :]
-                    _apply_residual(hidden_states, add, control_scale)
+                # ---- ControlNet per-layer residual adds (device/dtype aligned; safe overlap) ----
+                if c_input_img is not None and i < len(c_input_img):
+                    add = _to_dev_dtype(c_input_img[i], hidden_states)
+                    if add is not None:
+                        if add.dim() == 3 and hidden_states.dim() == 3 and add.shape[1] > hidden_states.shape[1]:
+                            add = add[:, :hidden_states.shape[1], :]
+                        _apply_residual(hidden_states, add, control_scale)
 
-            if c_input_txt is not None and i < len(c_input_txt):
-                addt = _to_dev_dtype(c_input_txt[i], encoder_hidden_states)
-                if addt is not None:
-                    if addt.dim() == 3 and encoder_hidden_states.dim() == 3 and addt.shape[1] > encoder_hidden_states.shape[1]:
-                        addt = addt[:, :encoder_hidden_states.shape[1], :]
-                    _apply_residual(encoder_hidden_states, addt, control_scale)
+                if c_input_txt is not None and i < len(c_input_txt):
+                    addt = _to_dev_dtype(c_input_txt[i], encoder_hidden_states)
+                    if addt is not None:
+                        if addt.dim() == 3 and encoder_hidden_states.dim() == 3 and addt.shape[1] > encoder_hidden_states.shape[1]:
+                            addt = addt[:, :encoder_hidden_states.shape[1], :]
+                        _apply_residual(encoder_hidden_states, addt, control_scale)
 
-            if c_output_img is not None and i < len(c_output_img):
-                addo = _to_dev_dtype(c_output_img[i], hidden_states)
-                if addo is not None:
-                    if addo.dim() == 3 and hidden_states.dim() == 3 and addo.shape[1] > hidden_states.shape[1]:
-                        addo = addo[:, :hidden_states.shape[1], :]
-                    _apply_residual(hidden_states, addo, control_scale)
+                if c_output_img is not None and i < len(c_output_img):
+                    addo = _to_dev_dtype(c_output_img[i], hidden_states)
+                    if addo is not None:
+                        if addo.dim() == 3 and hidden_states.dim() == 3 and addo.shape[1] > hidden_states.shape[1]:
+                            addo = addo[:, :hidden_states.shape[1], :]
+                        _apply_residual(hidden_states, addo, control_scale)
 
-            if c_output_txt is not None and i < len(c_output_txt):
-                addot = _to_dev_dtype(c_output_txt[i], encoder_hidden_states)
-                if addot is not None:
-                    if addot.dim() == 3 and encoder_hidden_states.dim() == 3 and addot.shape[1] > encoder_hidden_states.shape[1]:
-                        addot = addot[:, :encoder_hidden_states.shape[1], :]
-                    _apply_residual(encoder_hidden_states, addot, control_scale)
+                if c_output_txt is not None and i < len(c_output_txt):
+                    addot = _to_dev_dtype(c_output_txt[i], encoder_hidden_states)
+                    if addot is not None:
+                        if addot.dim() == 3 and encoder_hidden_states.dim() == 3 and addot.shape[1] > encoder_hidden_states.shape[1]:
+                            addot = addot[:, :encoder_hidden_states.shape[1], :]
+                        _apply_residual(encoder_hidden_states, addot, control_scale)
 
-            if self.offload and self.offload_manager is not None:
-                self.offload_manager.step(torch.cuda.current_stream())
+            if self.offload:
+                self.offload_manager.step(compute_stream)
 
         hidden_states = self.norm_out(hidden_states, temb)
         hidden_states = self.proj_out(hidden_states)
@@ -595,15 +860,42 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
         return hidden_states.reshape(orig_shape)[:, :, :, : x.shape[-2], : x.shape[-1]]
 
     def set_offload(self, offload: bool, **kwargs):
-        if offload == getattr(self, "offload", False):
+        """
+        Enable or disable CPU offloading for the transformer blocks.
+
+        Parameters
+        ----------
+        offload : bool
+            If True, enable CPU offloading. If False, disable it.
+        **kwargs
+            Additional keyword arguments:
+                - use_pin_memory (bool): Whether to use pinned memory (default: True).
+                - num_blocks_on_gpu (int): Number of transformer blocks to keep on GPU (default: 1).
+
+        Notes
+        -----
+        - When offloading is enabled, only a subset of modules remain on GPU.
+        - When disabling, memory is released and CUDA cache is cleared.
+        """
+        if offload == self.offload:
+            # Nothing changed, just return
             return
         self.offload = offload
         if offload:
             self.offload_manager = CPUOffloadManager(
                 self.transformer_blocks,
                 use_pin_memory=kwargs.get("use_pin_memory", True),
-                on_gpu_modules=[self.img_in, self.txt_in, self.txt_norm, self.time_text_embed, self.norm_out, self.proj_out],
+                on_gpu_modules=[
+                    self.img_in,
+                    self.txt_in,
+                    self.txt_norm,
+                    self.time_text_embed,
+                    self.norm_out,
+                    self.proj_out,
+                ],
                 num_blocks_on_gpu=kwargs.get("num_blocks_on_gpu", 1),
             )
         else:
             self.offload_manager = None
+            gc.collect()
+            torch.cuda.empty_cache()

--- a/models/qwenimage.py
+++ b/models/qwenimage.py
@@ -614,29 +614,6 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
         )
         self.gradient_checkpointing = False
 
-    def forward(
-        self,
-        x,
-        timesteps,
-        context,
-        attention_mask=None,
-        guidance: torch.Tensor = None,
-        ref_latents=None,
-        transformer_options={},
-        **kwargs,
-    ):
-        """Public forward wrapper keeping ComfyUI Qwen-Image interface; delegates to _forward."""
-        return self._forward(
-            x,
-            timesteps,
-            context,
-            attention_mask=attention_mask,
-            guidance=guidance,
-            ref_latents=ref_latents,
-            transformer_options=transformer_options,
-            **kwargs,
-        )
-
     def _forward(
         self,
         x,

--- a/models/qwenimage.py
+++ b/models/qwenimage.py
@@ -27,7 +27,7 @@ from nunchaku.models.utils import CPUOffloadManager
 from nunchaku.ops.fused import fused_gelu_mlp
 
 from ..mixins.model import NunchakuModelMixin
-import comfy.patcher_extension
+import comfy.patcher_extension  # required for WrapperExecutor (forward wrapper)
 
 
 class NunchakuGELU(GELU):
@@ -614,30 +614,69 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
             device=device,
         )
         self.gradient_checkpointing = False
+
     def forward(
+
         self,
+
         x,
+
         timesteps,
+
         context,
+
         attention_mask=None,
+
         guidance=None,
+
         ref_latents=None,
+
         transformer_options={},
+
         control=None,
+
         **kwargs,
+
     ):
+
         """Forward wrapper: explicitly pass `control` to `_forward` via WrapperExecutor.
-        Source: mirrors ComfyUI qwen_image/model.py forward wrapper semantics.
+
+        Mirrors ComfyUI qwen_image/model.py forward wrapper semantics.
+
         """
+
         return comfy.patcher_extension.WrapperExecutor.new_class_executor(
+
             self._forward,
+
             self,
+
             comfy.patcher_extension.get_all_wrappers(
-                comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options
+
+                comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options,
+
             ),
+
         ).execute(
-            x, timesteps, context, attention_mask, guidance,
-            ref_latents, transformer_options, control, **kwargs
+
+            x,
+
+            timesteps,
+
+            context,
+
+            attention_mask,
+
+            guidance,
+
+            ref_latents,
+
+            transformer_options,
+
+            control,
+
+            **kwargs,
+
         )
 
 

--- a/models/qwenimage.py
+++ b/models/qwenimage.py
@@ -27,6 +27,7 @@ from nunchaku.models.utils import CPUOffloadManager
 from nunchaku.ops.fused import fused_gelu_mlp
 
 from ..mixins.model import NunchakuModelMixin
+import comfy.patcher_extension
 
 
 class NunchakuGELU(GELU):
@@ -613,6 +614,32 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
             device=device,
         )
         self.gradient_checkpointing = False
+    def forward(
+        self,
+        x,
+        timesteps,
+        context,
+        attention_mask=None,
+        guidance=None,
+        ref_latents=None,
+        transformer_options={},
+        control=None,
+        **kwargs,
+    ):
+        """Forward wrapper: explicitly pass `control` to `_forward` via WrapperExecutor.
+        Source: mirrors ComfyUI qwen_image/model.py forward wrapper semantics.
+        """
+        return comfy.patcher_extension.WrapperExecutor.new_class_executor(
+            self._forward,
+            self,
+            comfy.patcher_extension.get_all_wrappers(
+                comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options
+            ),
+        ).execute(
+            x, timesteps, context, attention_mask, guidance,
+            ref_latents, transformer_options, control, **kwargs
+        )
+
 
     def _forward(
         self,
@@ -654,10 +681,6 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
             Output tensor of shape (batch, channels, height, width), matching the input spatial dimensions.
 
         """
-        # ControlNet fallback: if `control` wasn't explicitly passed, try transformer_options or kwargs.
-        # Source: ComfyUI Qwen-Image forward/_forward behavior (ensures ControlNet residuals aren't lost via wrapper kwargs).
-        control = control or (transformer_options.get("control") if isinstance(transformer_options, dict) else None) or (kwargs.get("control") if isinstance(kwargs, dict) else None)
-
         device = x.device
         if self.offload:
             self.offload_manager.set_device(device)

--- a/models/qwenimage.py
+++ b/models/qwenimage.py
@@ -758,7 +758,11 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
                         image_rotary_emb=image_rotary_emb,
                     )
                 # ControlNet helpers(device/dtype-safe residual adds)
-                _control = control if control is not None else (transformer_options.get("control", None) if isinstance(transformer_options, dict) else None)
+                _control = (
+                    control
+                    if control is not None
+                    else (transformer_options.get("control", None) if isinstance(transformer_options, dict) else None)
+                )
                 if isinstance(_control, dict):
                     control_i = _control.get("input")
                     try:
@@ -771,7 +775,10 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
                 if control_i is not None and i < len(control_i):
                     add = control_i[i]
                     if add is not None:
-                        if getattr(add, 'device', None) != hidden_states.device or getattr(add, 'dtype', None) != hidden_states.dtype:
+                        if (
+                            getattr(add, "device", None) != hidden_states.device
+                            or getattr(add, "dtype", None) != hidden_states.dtype
+                        ):
                             add = add.to(device=hidden_states.device, dtype=hidden_states.dtype, non_blocking=True)
                         t = min(hidden_states.shape[1], add.shape[1])
                         if t > 0:


### PR DESCRIPTION
Add a ControlNet fallback at the beginning of _forward(...): before device = x.device, recover control from transformer_options and kwargs to guard against implicit control passthrough being dropped in certain execution paths, which would otherwise prevent ControlNet injection from taking effect.