### PR TITLE
Update install_wheel.json to install the latest stable version.

### DIFF
--- a/example_workflows/install_wheel.json
+++ b/example_workflows/install_wheel.json
@@ -63,8 +63,8 @@
         "Node name for S&R": "NunchakuWheelInstaller"
       },
       "widgets_values": [
+        "latest",
         "none",
-        "1.0.1.dev20250912",
         "install"
       ]
     },


### PR DESCRIPTION
The PR updates `install_wheel.json` to install the latest stable version instead of the nightly version `1.0.1.dev20250912`.

The existing documentation states that:

> Selecting 'latest' triggers an online update of the local version lists before installing, ensuring a simple, reliable, and error-free user experience.